### PR TITLE
Allow for reverse motion but no reverse acceleration

### DIFF
--- a/src/brains2/include/brains2/sim/sim.hpp
+++ b/src/brains2/include/brains2/sim/sim.hpp
@@ -61,7 +61,6 @@ public:
                 return "UNKNOWN_ERROR";
         }
     }
-    // static const std::array<std::string, 4> SimErrorStrings;
 
     // We remove the default constructor, copy constructor and assignment operator because this
     // class has to allocate data on the heap (for the acados simulation solver and the casadi

--- a/src/brains2/src/sim/sim.cpp
+++ b/src/brains2/src/sim/sim.cpp
@@ -228,12 +228,5 @@ tl::expected<std::pair<Sim::State, Sim::Accels>, Sim::SimError> Sim::simulate(
         return tl::make_unexpected(SimError::NANS_IN_RESULT);
     }
 
-    // if (next_state.v_x < 0.0 or
-    //     (next_state.tau_FL <= 0.1 and next_state.tau_FR <= 0.1 and next_state.tau_RL <= 0.1 and
-    //      next_state.tau_RR <= 0.1 and next_state.v_x <= 0.01)) {
-    //     next_state.v_x = 0.0;
-    //     next_state.v_y = 0.0;
-    //     next_state.omega = 0.0;
-    // }
     return std::make_pair(next_state, next_accels);
 }


### PR DESCRIPTION
Now we artificially set the input torques to 0 when they are negative **and** the car is driving backwards ($v_x<0$).
This allows:
- To still apply negative acceleration when the car is driving forwards ($v_>0$) to simulate a _braking system_.
- Not to apply a negative acceleration when the velocity crosses 0 (which would simulate a _reverse gear_).
- The car to slip when exceeding the grip limits and start turning and driving backwards (just based on the road friction).