### PR TITLE
specify all headers in `brains2/external` as system includes

### DIFF
--- a/src/brains2/CMakeLists.txt
+++ b/src/brains2/CMakeLists.txt
@@ -19,6 +19,8 @@ endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include_directories(include)
+add_compile_options(--system-header-prefix=brains2/external/)
+
 add_compile_definitions(TRACK_DATABASE_PATH="${CMAKE_CURRENT_SOURCE_DIR}/../../track_database")
 add_compile_definitions(CAR_CONSTANTS_PATH="${CMAKE_CURRENT_SOURCE_DIR}/../../car_constants.yaml")
 


### PR DESCRIPTION
Fixes #26 thanks to the following [`clang` flag](https://clang.llvm.org/docs/UsersManual.html#controlling-diagnostics-in-system-headers)