### PR TITLE
add new markers in control node

### DIFF
--- a/foxglove_template.json
+++ b/foxglove_template.json
@@ -3,7 +3,7 @@
     "3D!3mfo4f7": {
       "cameraState": {
         "perspective": true,
-        "distance": 0.6434451771224811,
+        "distance": 0.875326180751886,
         "phi": 85,
         "thetaOffset": 90,
         "targetOffset": [
@@ -250,9 +250,9 @@
     "3D!2u59b2d": {
       "cameraState": {
         "perspective": true,
-        "distance": 12.604988194492096,
-        "phi": 56.04793647469353,
-        "thetaOffset": 87.23607659729088,
+        "distance": 11.974738784767489,
+        "phi": 56.047936474693465,
+        "thetaOffset": 87.23607659729625,
         "targetOffset": [
           0,
           0,
@@ -416,6 +416,9 @@
             },
             "": {
               "visible": false
+            },
+            "traj_ref": {
+              "visible": true
             }
           }
         },
@@ -466,6 +469,180 @@
       "imageMode": {},
       "followTf": "car"
     },
+    "Plot!1eym6x4": {
+      "paths": [
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/brains2/control/debug_info.s_ref[:]",
+          "enabled": true,
+          "color": "#4e98e2",
+          "xValuePath": "",
+          "label": "s_ref"
+        },
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/brains2/control/debug_info.s_pred[:]",
+          "enabled": true,
+          "color": "#f5774d",
+          "label": "s_pred"
+        }
+      ],
+      "showXAxisLabels": true,
+      "showYAxisLabels": true,
+      "showLegend": true,
+      "legendDisplay": "none",
+      "showPlotValuesInLegend": false,
+      "isSynced": false,
+      "xAxisVal": "index",
+      "sidebarDimension": 240,
+      "foxglovePanelTitle": "track progress (m)",
+      "xAxisLabel": "stage"
+    },
+    "Plot!3tlbpqo": {
+      "paths": [
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/brains2/control/debug_info.n_ref[:]",
+          "enabled": true,
+          "color": "#4e98e2",
+          "xValuePath": "",
+          "label": "n_ref"
+        },
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/brains2/control/debug_info.n_pred[:]",
+          "enabled": true,
+          "color": "#f5774d",
+          "label": "n_pred"
+        }
+      ],
+      "showXAxisLabels": true,
+      "showYAxisLabels": true,
+      "showLegend": true,
+      "legendDisplay": "none",
+      "showPlotValuesInLegend": false,
+      "isSynced": false,
+      "xAxisVal": "index",
+      "sidebarDimension": 240,
+      "foxglovePanelTitle": "lateral deviation (m)",
+      "xAxisLabel": "stage"
+    },
+    "Plot!1p2pcj1": {
+      "paths": [
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/brains2/control/debug_info.v_ref[:]",
+          "enabled": true,
+          "color": "#4e98e2",
+          "xValuePath": "",
+          "label": "v_ref"
+        },
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/brains2/control/debug_info.v_pred[:]",
+          "enabled": true,
+          "color": "#f5774d",
+          "label": "v_pred"
+        }
+      ],
+      "showXAxisLabels": true,
+      "showYAxisLabels": true,
+      "showLegend": true,
+      "legendDisplay": "none",
+      "showPlotValuesInLegend": false,
+      "isSynced": false,
+      "xAxisVal": "index",
+      "sidebarDimension": 240,
+      "foxglovePanelTitle": "velocity (m/s)",
+      "xAxisLabel": "stage"
+    },
+    "Plot!42k3715": {
+      "paths": [
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/brains2/control/debug_info.psi_ref[:]",
+          "enabled": true,
+          "color": "#4e98e2",
+          "xValuePath": "",
+          "label": "psi_ref"
+        },
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/brains2/control/debug_info.psi_pred[:]",
+          "enabled": true,
+          "color": "#f5774d",
+          "label": "psi_pred"
+        }
+      ],
+      "showXAxisLabels": true,
+      "showYAxisLabels": true,
+      "showLegend": true,
+      "legendDisplay": "none",
+      "showPlotValuesInLegend": false,
+      "isSynced": false,
+      "xAxisVal": "index",
+      "sidebarDimension": 240,
+      "foxglovePanelTitle": "angular deviation (rad)",
+      "xAxisLabel": "stage"
+    },
+    "Plot!4e116sl": {
+      "paths": [
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/brains2/control/debug_info.tau_ref[:]",
+          "enabled": true,
+          "color": "#4e98e2",
+          "xValuePath": "",
+          "label": "tau_ref"
+        },
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/brains2/control/debug_info.tau_pred[:]",
+          "enabled": true,
+          "color": "#f5774d",
+          "label": "tau_pred"
+        }
+      ],
+      "showXAxisLabels": true,
+      "showYAxisLabels": true,
+      "showLegend": true,
+      "legendDisplay": "none",
+      "showPlotValuesInLegend": false,
+      "isSynced": false,
+      "xAxisVal": "index",
+      "sidebarDimension": 240,
+      "foxglovePanelTitle": "torque (Nm)",
+      "xAxisLabel": "stage"
+    },
+    "Plot!2njw5m3": {
+      "paths": [
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/brains2/control/debug_info.delta_ref[:]",
+          "enabled": true,
+          "color": "#4e98e2",
+          "xValuePath": "",
+          "label": "delta_ref"
+        },
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/brains2/control/debug_info.delta_pred[:]",
+          "enabled": true,
+          "color": "#f5774d",
+          "label": "delta_pred"
+        }
+      ],
+      "showXAxisLabels": true,
+      "showYAxisLabels": true,
+      "showLegend": true,
+      "legendDisplay": "none",
+      "showPlotValuesInLegend": false,
+      "isSynced": false,
+      "xAxisVal": "index",
+      "sidebarDimension": 240,
+      "foxglovePanelTitle": "steering (rad)",
+      "xAxisLabel": "stage"
+    },
     "Plot!3ra6qj8": {
       "paths": [
         {
@@ -495,12 +672,12 @@
         "value": "/brains2/acceleration.a_y"
       },
       "followingViewWidth": 10,
-      "foxglovePanelTitle": "steering (rad)"
+      "foxglovePanelTitle": "closed-loop steering (rad)"
     },
     "Plot!3lwo8o7": {
       "paths": [
         {
-          "value": "/brains2/diagnostics.status[:]{hardware_id==\"\"}{name==\"control_node\"}.values[:]{key==\"runtime (ms)\"}.value",
+          "value": "/brains2/diagnostics.status[:]{hardware_id==\"\"}{name==\"high_level_controller\"}.values[:]{key==\"runtime (ms)\"}.value",
           "enabled": true,
           "timestampMethod": "headerStamp",
           "label": "runtime"
@@ -535,7 +712,7 @@
       "xAxisVal": "timestamp",
       "sidebarDimension": 240,
       "followingViewWidth": 10,
-      "foxglovePanelTitle": "speed (m/s)"
+      "foxglovePanelTitle": "closed-loop velocity (m/s)"
     },
     "Plot!1zeuiyp": {
       "paths": [
@@ -563,7 +740,10 @@
       "xAxisVal": "timestamp",
       "sidebarDimension": 240,
       "followingViewWidth": 10,
-      "foxglovePanelTitle": "torque per wheel (Nm)"
+      "foxglovePanelTitle": "closed-loop torque per wheel (Nm)"
+    },
+    "DiagnosticStatusPanel!6s2wmp": {
+      "topicToRender": "/brains2/diagnostics"
     },
     "Brains2 Extensions.Call Service Button!2wnmi6j": {
       "service": "/brains2/reset",
@@ -611,7 +791,32 @@
         {
           "title": "control",
           "layout": {
-            "first": "3D!2u59b2d",
+            "first": {
+              "first": "3D!2u59b2d",
+              "second": {
+                "first": {
+                  "first": {
+                    "first": "Plot!1eym6x4",
+                    "second": "Plot!3tlbpqo",
+                    "direction": "row"
+                  },
+                  "second": {
+                    "first": "Plot!1p2pcj1",
+                    "second": "Plot!42k3715",
+                    "direction": "row"
+                  },
+                  "direction": "column"
+                },
+                "second": {
+                  "first": "Plot!4e116sl",
+                  "second": "Plot!2njw5m3",
+                  "direction": "row"
+                },
+                "direction": "column",
+                "splitPercentage": 70.82104285216585
+              },
+              "direction": "row"
+            },
             "second": {
               "first": {
                 "first": {
@@ -627,15 +832,21 @@
                 "direction": "row"
               },
               "second": {
-                "first": "Brains2 Extensions.Call Service Button!2wnmi6j",
+                "first": {
+                  "first": "DiagnosticStatusPanel!6s2wmp",
+                  "second": "Brains2 Extensions.Call Service Button!2wnmi6j",
+                  "direction": "column",
+                  "splitPercentage": 76.91321465827639
+                },
                 "second": "Brains2 Extensions.Call Service Button!3tt1tjl",
-                "direction": "column"
+                "direction": "column",
+                "splitPercentage": 83.50214257888584
               },
               "direction": "row",
-              "splitPercentage": 91.44021739130434
+              "splitPercentage": 80.73322932917316
             },
             "direction": "column",
-            "splitPercentage": 64.69893742621015
+            "splitPercentage": 64.34474616292798
           }
         },
         {

--- a/launch/v0.yml
+++ b/launch/v0.yml
@@ -10,7 +10,7 @@ launch:
       default: "20"
   - arg:
       name: "v_ref"
-      default: "6.0"
+      default: "6.5"
   - arg:
       name: "q_s"
       default: "10.0"

--- a/src/brains2/CMakeLists.txt
+++ b/src/brains2/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 ####################################################################################################
 set(msg_files
   "msg/Acceleration.msg"
+  "msg/ControllerDebugInfo.msg"
   "msg/Controls.msg"
   "msg/Map.msg"
   "msg/Pose.msg"

--- a/src/brains2/include/brains2/control/controller.hpp
+++ b/src/brains2/include/brains2/control/controller.hpp
@@ -41,15 +41,13 @@ public:
                const SolverParams& solver_params = {false, "fatrop"});
 
     struct State {
-        static constexpr uint8_t dim = 4;
         double s, n, psi, v;
     };
     struct Control {
-        static constexpr uint8_t dim = 2;
         double delta, tau;
     };
-    static constexpr uint8_t nx = State::dim;
-    static constexpr uint8_t nu = Control::dim;
+    static constexpr uint8_t nx = sizeof(State) / sizeof(double);
+    static constexpr uint8_t nu = sizeof(Control) / sizeof(double);
     typedef Eigen::Matrix<double, nx, Eigen::Dynamic> StateHorizonMatrix;
     typedef Eigen::Matrix<double, nu, Eigen::Dynamic> ControlHorizonMatrix;
 
@@ -71,6 +69,13 @@ public:
      */
     tl::expected<Control, Error> compute_control(const State& current_state,
                                                  const brains2::common::Track& track);
+
+    /*
+     * @brief Get the horizon size.
+     */
+    inline size_t horizon_size() const {
+        return Nf;
+    }
 
     /*
      * @brief Const ref getter to the optimal state trajectory. May contain outdated data if

--- a/src/brains2/msg/ControllerDebugInfo.msg
+++ b/src/brains2/msg/ControllerDebugInfo.msg
@@ -1,0 +1,14 @@
+# Copyright (c) 2024. Tudor Oancea, Matteo Berthet
+std_msgs/Header header
+float64[] s_ref
+float64[] n_ref
+float64[] psi_ref
+float64[] v_ref
+float64[] delta_ref
+float64[] tau_ref
+float64[] s_pred
+float64[] n_pred
+float64[] psi_pred
+float64[] v_pred
+float64[] delta_pred
+float64[] tau_pred

--- a/src/brains2/src/control/control_node.cpp
+++ b/src/brains2/src/control/control_node.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2024. Tudor Oancea, Matteo Berthet
 #include <cstdint>
 #include <memory>
+#include <rclcpp/logging.hpp>
 #include <tuple>
 #include "brains2/common/cone_color.hpp"
 #include "brains2/common/marker_color.hpp"
@@ -9,8 +10,8 @@
 #include "brains2/control/controller.hpp"
 #include "brains2/external/expected.hpp"
 #include "brains2/external/icecream.hpp"
+#include "brains2/msg/controller_debug_info.hpp"
 #include "brains2/msg/controls.hpp"
-#include "brains2/msg/detail/velocity__struct.hpp"
 #include "brains2/msg/pose.hpp"
 #include "brains2/msg/track_estimate.hpp"
 #include "brains2/msg/velocity.hpp"
@@ -30,6 +31,7 @@ using namespace std;
 using namespace brains2::msg;
 using namespace brains2::common;
 using namespace brains2::control;
+using diagnostic_msgs::msg::DiagnosticArray;
 using rclcpp::Publisher;
 using rclcpp::Subscription;
 using visualization_msgs::msg::Marker;
@@ -39,12 +41,12 @@ class ControlNode : public rclcpp::Node {
 public:
     ControlNode() : Node("control_node") {
         const auto dt = 1 / this->declare_parameter("freq", 20.0);
-        const auto Nf = this->declare_parameter("Nf", 10);
+        const auto Nf = this->declare_parameter("Nf", 20);
 
         // load yaml file with car constants
 #ifdef CAR_CONSTANTS_PATH
         YAML::Node car_constants = YAML::LoadFile(CAR_CONSTANTS_PATH);
-        const brains2::control::Controller::ModelParams model_params{
+        const Controller::ModelParams model_params{
             dt,
             car_constants["inertia"]["mass"].as<double>(),
             car_constants["geometry"]["cog_to_rear_axle"].as<double>(),
@@ -57,18 +59,19 @@ public:
         };
 
         // Limits
-        const brains2::control::Controller::ConstraintsParams constraints_params{
+        const Controller::ConstraintsParams constraints_params{
             this->declare_parameter("v_x_max", 10.0),
             this->declare_parameter("delta_max", 0.5),
             this->declare_parameter("tau_max", 100.0),
             car_constants["geometry"]["car_width"].as<double>() +
                 this->declare_parameter("car_width_inflation", 0.0)};
+        this->car_width = car_constants["geometry"]["car_width"].as<double>();
 #else
 #error CAR_CONSTANTS_PATH is not defined
 #endif
 
         // cost params
-        const brains2::control::Controller::CostParams cost_params{
+        const Controller::CostParams cost_params{
             this->declare_parameter("v_ref", 5.0),
             this->declare_parameter("q_s", 1.0),
             this->declare_parameter("q_n", 1.0),
@@ -82,17 +85,17 @@ public:
             this->declare_parameter("q_v_f", 1.0),
         };
 
-        const brains2::control::Controller::SolverParams solver_params{
+        const Controller::SolverParams solver_params{
             this->declare_parameter("jit", false),
             this->declare_parameter("solver", "fatrop"),
         };
 
         // Create controller object
-        this->controller = std::make_unique<brains2::control::Controller>(static_cast<size_t>(Nf),
-                                                                          model_params,
-                                                                          constraints_params,
-                                                                          cost_params,
-                                                                          solver_params);
+        this->controller = std::make_unique<Controller>(static_cast<size_t>(Nf),
+                                                        model_params,
+                                                        constraints_params,
+                                                        cost_params,
+                                                        solver_params);
 
         // Publishers and subscribers
         this->target_controls_pub =
@@ -103,6 +106,8 @@ public:
         this->diagnostics_pub =
             this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/brains2/diagnostics",
                                                                           10);
+        this->debug_info_pub =
+            this->create_publisher<ControllerDebugInfo>("/brains2/control/debug_info", 10);
         this->track_estimate_sub = this->create_subscription<TrackEstimate>(
             "/brains2/track_estimate",
             10,
@@ -116,60 +121,44 @@ public:
             10,
             std::bind(&ControlNode::vel_cb, this, std::placeholders::_1));
 
-        // Diagnostics
-        this->diag_msg.status.resize(1);
-        this->diag_msg.status[0].name = "control_node";
-        this->diag_msg.status[0].level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-        this->diag_msg.status[0].message = "OK";
-        this->diag_msg.status[0].values.resize(1);
-        this->diag_msg.status[0].values[0].key = "runtime (ms)";
-
-        // Markers
-        this->viz_msg.markers.resize(2);
-
-        this->viz_msg.markers[0].header.frame_id = "world";
-        this->viz_msg.markers[0].ns = "traj_pred";
-        this->viz_msg.markers[0].action = visualization_msgs::msg::Marker::MODIFY;
-        this->viz_msg.markers[0].type = visualization_msgs::msg::Marker::LINE_STRIP;
-        this->viz_msg.markers[0].points.resize(Nf + 1);
-        this->viz_msg.markers[0].scale.x = 0.05;
-        this->viz_msg.markers[0].color = marker_colors("green");
-
-        this->viz_msg.markers[1].header.frame_id = "world";
-        this->viz_msg.markers[1].ns = "traj_ref";
-        this->viz_msg.markers[1].action = visualization_msgs::msg::Marker::MODIFY;
-        this->viz_msg.markers[1].type = visualization_msgs::msg::Marker::LINE_STRIP;
-        this->viz_msg.markers[1].points.resize(Nf + 1);
-        this->viz_msg.markers[1].scale.x = 0.05;
-        this->viz_msg.markers[1].color = marker_colors("orange");
+        // Initialize messages
+        this->create_viz_msg();
+        this->create_diag_msg();
+        this->create_debug_info_msg();
     }
 
 private:
-    // publishers
-    Publisher<Controls>::SharedPtr target_controls_pub;
-    Publisher<MarkerArray>::SharedPtr viz_pub;
-    Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostics_pub;
+    /******************************************************************************
+     * Input data
+     ******************************************************************************/
 
-    // subscribers
-    Subscription<TrackEstimate>::SharedPtr track_estimate_sub;
+    // Pose
     Subscription<Pose>::SharedPtr pose_sub;
-    Subscription<Velocity>::SharedPtr vel_sub;
-
-    // messages
-    brains2::msg::Controls controls_msg;
-    visualization_msgs::msg::MarkerArray viz_msg;
-    diagnostic_msgs::msg::DiagnosticArray diag_msg;
-
-    // controller
-    unique_ptr<Track> track;
     Pose::ConstSharedPtr pose_msg;
-    Velocity::ConstSharedPtr vel_msg;
-    rclcpp::TimerBase::SharedPtr control_timer;
-    unique_ptr<brains2::control::Controller> controller;
 
-    // Counter to throw an error after 5 consecutive errors
-    uint8_t error_counter = 0;
-    static constexpr uint8_t MAX_ERROR_COUNT = 5;
+    void pose_cb(const Pose::ConstSharedPtr pose_msg) {
+        this->pose_msg = pose_msg;
+        // We launch the control timer upon receiving the first pose message and not velocity
+        // message because eventually (when we will have SLAM), the pose messages will likely be the
+        // ones that will be "late".
+        if (!this->control_timer) {
+            this->control_timer = this->create_wall_timer(
+                std::chrono::duration<double>(1 / this->get_parameter("freq").as_double()),
+                std::bind(&ControlNode::control_cb, this));
+        }
+    }
+
+    // Velocity
+    Subscription<Velocity>::SharedPtr vel_sub;
+    Velocity::ConstSharedPtr vel_msg;
+
+    void vel_cb(const Velocity::ConstSharedPtr vel_msg) {
+        this->vel_msg = vel_msg;
+    }
+
+    // Track Estimate
+    Subscription<TrackEstimate>::SharedPtr track_estimate_sub;
+    unique_ptr<Track> track;
 
     void track_estimate_cb(const TrackEstimate::ConstSharedPtr msg) {
         const auto track_expected = Track::from_values(msg->s_cen,
@@ -184,25 +173,21 @@ private:
                 "Could not construct Track object from received message because of error: %s",
                 to_string(track_expected.error()).c_str());
         } else {
-            this->track = std::make_unique<Track>(track_expected.value());
+            this->track = std::make_unique<Track>(*track_expected);
         }
     }
 
-    void pose_cb(const Pose::ConstSharedPtr pose_msg) {
-        this->pose_msg = pose_msg;
-        // We launch the control timer upon receiving the first pose message and not velocity
-        // message because eventually (when we will have SLAM), the pose messages will likely be the
-        // ones that will be "late".
-        if (!this->control_timer) {
-            this->control_timer = this->create_wall_timer(
-                std::chrono::duration<double>(1 / this->get_parameter("freq").as_double()),
-                std::bind(&ControlNode::control_cb, this));
-        }
-    }
-
-    void vel_cb(const Velocity::ConstSharedPtr vel_msg) {
-        this->vel_msg = vel_msg;
-    }
+    /******************************************************************************
+     * Output data
+     ******************************************************************************/
+    Publisher<Controls>::SharedPtr target_controls_pub;
+    Controls controls_msg;
+    rclcpp::TimerBase::SharedPtr control_timer;
+    unique_ptr<Controller> controller;
+    double car_width;
+    // Counter to throw an error after 5 consecutive errors
+    uint8_t error_counter = 0;
+    static constexpr uint8_t MAX_ERROR_COUNT = 5;
 
     void control_cb() {
         if (!this->pose_msg || !this->vel_msg) {
@@ -228,11 +213,11 @@ private:
         // Compute control
         const auto start = this->now();
         const auto control = this->controller->compute_control(state, *(this->track))
-                                 .transform([this](const auto& control) {
+                                 .transform([this](const auto &control) {
                                      error_counter = 0;
                                      return to_sim_control(control);
                                  })
-                                 .transform_error([this](const auto& error) {
+                                 .transform_error([this](const auto &error) {
                                      RCLCPP_ERROR(this->get_logger(),
                                                   "Error in MPC solver: %s",
                                                   to_string(error).c_str());
@@ -248,47 +233,178 @@ private:
         const auto end = this->now();
 
         // Publish controls
-        controls_msg.header.stamp = this->now();
-        controls_msg.tau_fl = control.u_tau_FL;
-        controls_msg.tau_fr = control.u_tau_FR;
-        controls_msg.tau_rl = control.u_tau_RL;
-        controls_msg.tau_rr = control.u_tau_RR;
-        controls_msg.delta = control.u_delta;
-        this->target_controls_pub->publish(controls_msg);
+        this->controls_msg.header.stamp = this->now();
+        this->controls_msg.tau_fl = control.u_tau_FL;
+        this->controls_msg.tau_fr = control.u_tau_FR;
+        this->controls_msg.tau_rl = control.u_tau_RL;
+        this->controls_msg.tau_rr = control.u_tau_RR;
+        this->controls_msg.delta = control.u_delta;
+        this->target_controls_pub->publish(this->controls_msg);
 
         // Publish diagnostics
-        diag_msg.header.stamp = this->now();
-        diag_msg.status[0].values[0].value = to_string(1000 * (end - start).seconds());
-        diagnostics_pub->publish(diag_msg);
+        this->update_diag_msg(1000 * (end - start).seconds());
+        this->diagnostics_pub->publish(this->diag_msg);
 
         // Publish visualization
-        const auto x_opt = this->controller->get_x_opt();
-        const auto x_ref = this->controller->get_x_ref();
-        for (long i = 0; i < x_opt.cols(); ++i) {
-            // predicted trajectory
-            const auto [pose, _] = track->frenet_to_cartesian(
-                FrenetPose{frenet_pose.s + x_opt(0, i), x_opt(1, i), x_opt(2, i)});
-            viz_msg.markers[0].points[i].x = pose.X;
-            viz_msg.markers[0].points[i].y = pose.Y;
-            viz_msg.markers[0].points[i].z = 0.1;
+        this->update_viz_msg(frenet_pose.s,
+                             this->controller->get_x_ref(),
+                             this->controller->get_x_opt());
+        this->viz_pub->publish(this->viz_msg);
 
+        // Publish other debug information
+        this->update_debug_info_msg(this->controller->get_x_ref(),
+                                    this->controller->get_u_ref(),
+                                    this->controller->get_x_opt(),
+                                    this->controller->get_u_opt());
+        this->debug_info_pub->publish(this->debug_info_msg);
+    }
+
+    Publisher<MarkerArray>::SharedPtr viz_pub;
+    MarkerArray viz_msg;
+
+    void create_viz_msg() {
+        this->viz_msg.markers.resize(4);
+
+        // Predicted trajectory
+        this->viz_msg.markers[0].header.frame_id = "world";
+        this->viz_msg.markers[0].ns = "traj_pred";
+        this->viz_msg.markers[0].action = visualization_msgs::msg::Marker::MODIFY;
+        this->viz_msg.markers[0].type = visualization_msgs::msg::Marker::LINE_STRIP;
+        this->viz_msg.markers[0].points.resize(this->controller->horizon_size() + 1);
+        this->viz_msg.markers[0].scale.x = 0.05;
+        this->viz_msg.markers[0].color = marker_colors("green");
+
+        // Reference trajectory
+        this->viz_msg.markers[1].header.frame_id = "world";
+        this->viz_msg.markers[1].ns = "traj_ref";
+        this->viz_msg.markers[1].action = visualization_msgs::msg::Marker::MODIFY;
+        this->viz_msg.markers[1].type = visualization_msgs::msg::Marker::LINE_STRIP;
+        this->viz_msg.markers[1].points.resize(this->controller->horizon_size() + 1);
+        this->viz_msg.markers[1].scale.x = 0.05;
+        this->viz_msg.markers[1].color = marker_colors("orange");
+
+        // Adjusted left boundary (blue)
+        this->viz_msg.markers[2].header.frame_id = "world";
+        this->viz_msg.markers[2].ns = "boundary_left";
+        this->viz_msg.markers[2].action = visualization_msgs::msg::Marker::MODIFY;
+        this->viz_msg.markers[2].type = visualization_msgs::msg::Marker::LINE_STRIP;
+        this->viz_msg.markers[2].points.resize(this->controller->horizon_size() + 1);
+        this->viz_msg.markers[2].scale.x = 0.05;
+        this->viz_msg.markers[2].color = marker_colors("blue");
+
+        // Adjusted right boundary (yellow)
+        this->viz_msg.markers[3].header.frame_id = "world";
+        this->viz_msg.markers[3].ns = "boundary_right";
+        this->viz_msg.markers[3].action = visualization_msgs::msg::Marker::MODIFY;
+        this->viz_msg.markers[3].type = visualization_msgs::msg::Marker::LINE_STRIP;
+        this->viz_msg.markers[3].points.resize(this->controller->horizon_size() + 1);
+        this->viz_msg.markers[3].scale.x = 0.05;
+        this->viz_msg.markers[3].color = marker_colors("yellow");
+    }
+
+    void update_viz_msg(const double s,
+                        const Controller::StateHorizonMatrix &x_ref,
+                        const Controller::StateHorizonMatrix &x_opt) {
+        if (!track) {
+            return;
+        }
+        for (long i = 0; i < this->controller->horizon_size() + 1; ++i) {
             // reference trajectory
-            const auto s_ref = frenet_pose.s + x_ref(0, i), X_ref = track->eval_X(s_ref),
+            const auto s_ref = s + x_ref(0, i), X_ref = track->eval_X(s_ref),
                        Y_ref = track->eval_Y(s_ref);
             viz_msg.markers[1].points[i].x = X_ref;
             viz_msg.markers[1].points[i].y = Y_ref;
             viz_msg.markers[1].points[i].z = 0.05;
+
+            // predicted trajectory
+            const auto [X, Y, _] =
+                track->frenet_to_cartesian(FrenetPose{s + x_opt(0, i), x_opt(1, i), x_opt(2, i)})
+                    .first;
+            viz_msg.markers[0].points[i].x = X;
+            viz_msg.markers[0].points[i].y = Y;
+            viz_msg.markers[0].points[i].z = 0.1;
+
+            // TODO: add boundaries
+            const auto phi_ref = track->eval_phi(s_ref);
+            const auto deviation =
+                track->eval_width(s_ref) -
+                (car_width + this->get_parameter("car_width_inflation").as_double()) / 2;
+            viz_msg.markers[2].points[i].x = X_ref - deviation * sin(phi_ref);
+            viz_msg.markers[2].points[i].y = Y_ref + deviation * cos(phi_ref);
+            viz_msg.markers[3].points[i].x = X_ref + deviation * sin(phi_ref);
+            viz_msg.markers[3].points[i].y = Y_ref - deviation * cos(phi_ref);
         }
-        viz_pub->publish(viz_msg);
+    }
+
+    DiagnosticArray diag_msg;
+    Publisher<DiagnosticArray>::SharedPtr diagnostics_pub;
+
+    void create_diag_msg() {
+        this->diag_msg.status.resize(1);
+        this->diag_msg.status[0].name = "high_level_controller";
+        this->diag_msg.status[0].values.resize(1);
+        this->diag_msg.status[0].values[0].key = "runtime (ms)";
+        // TODO: add second status for LLC
+    }
+
+    void update_diag_msg(const double runtime_ms) {
+        this->diag_msg.header.stamp = this->now();
+        // TODO: report internal status here (nominal, sending last prediction, crashed)
+        this->diag_msg.status[0].level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+        this->diag_msg.status[0].message = "nominal";
+        this->diag_msg.status[0].values[0].value = to_string(runtime_ms);
+    }
+
+    ControllerDebugInfo debug_info_msg;
+    Publisher<ControllerDebugInfo>::SharedPtr debug_info_pub;
+
+    void create_debug_info_msg() {
+        const auto Nf = this->controller->horizon_size();
+        this->debug_info_msg.s_ref.resize(Nf + 1);
+        this->debug_info_msg.n_ref.resize(Nf + 1);
+        this->debug_info_msg.psi_ref.resize(Nf + 1);
+        this->debug_info_msg.v_ref.resize(Nf + 1);
+        this->debug_info_msg.delta_ref.resize(Nf);
+        this->debug_info_msg.tau_ref.resize(Nf);
+        this->debug_info_msg.s_pred.resize(Nf + 1);
+        this->debug_info_msg.n_pred.resize(Nf + 1);
+        this->debug_info_msg.psi_pred.resize(Nf + 1);
+        this->debug_info_msg.v_pred.resize(Nf + 1);
+        this->debug_info_msg.delta_pred.resize(Nf);
+        this->debug_info_msg.tau_pred.resize(Nf);
+    }
+
+    void update_debug_info_msg(const Controller::StateHorizonMatrix &x_ref,
+                               const Controller::ControlHorizonMatrix &u_ref,
+                               const Controller::StateHorizonMatrix &x_pred,
+                               const Controller::ControlHorizonMatrix &u_pred) {
+        this->debug_info_msg.header.stamp = this->now();
+        const auto Nf = this->controller->horizon_size();
+        for (size_t i = 0; i < Nf + 1; ++i) {
+            this->debug_info_msg.s_ref[i] = x_ref(0, i);
+            this->debug_info_msg.n_ref[i] = x_ref(1, i);
+            this->debug_info_msg.psi_ref[i] = x_ref(2, i);
+            this->debug_info_msg.v_ref[i] = x_ref(3, i);
+            this->debug_info_msg.s_pred[i] = x_pred(0, i);
+            this->debug_info_msg.n_pred[i] = x_pred(1, i);
+            this->debug_info_msg.psi_pred[i] = x_pred(2, i);
+            this->debug_info_msg.v_pred[i] = x_pred(3, i);
+            if (i < Nf) {
+                this->debug_info_msg.delta_ref[i] = u_ref(0, i);
+                this->debug_info_msg.tau_ref[i] = u_ref(1, i);
+                this->debug_info_msg.delta_pred[i] = u_pred(0, i);
+                this->debug_info_msg.tau_pred[i] = u_pred(1, i);
+            }
+        }
     }
 };
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
     rclcpp::init(argc, argv);
     auto node = std::make_shared<ControlNode>();
     try {
         rclcpp::spin(node);
-    } catch (std::exception& e) {
+    } catch (std::exception &e) {
         RCLCPP_FATAL(node->get_logger(), "Caught exception: %s", e.what());
     }
     rclcpp::shutdown();


### PR DESCRIPTION
this PR:
- adds two additional markers for the left and right boundaries of the track (that are tightened by the car widths and the optional inflation)
- the `control_node` also publishes on a new topic `/brains2/control/debug_info` the reference and open-loop prediction of the MPC (i.e. the optimal values). We wanted to include them in the diagnostics but they need to be sent as `float64[]` instead of `string` to be able to be visualized in foxglove, so we had to create a new message type `ControllerDebugInfo`.
- the foxglove template now includes additional plot panels in the `control` tab for the open-loop predictions
- the `sim_node` now publishes the cones markers every 1s to facilitate viz in rosbags