### PR TITLE
Add low level controller (LLC)

### DIFF
--- a/foxglove_template.json
+++ b/foxglove_template.json
@@ -250,9 +250,9 @@
     "3D!2u59b2d": {
       "cameraState": {
         "perspective": true,
-        "distance": 11.974738784767489,
-        "phi": 56.047936474693465,
-        "thetaOffset": 87.23607659729625,
+        "distance": 10.8072017532524,
+        "phi": 56.04793647469345,
+        "thetaOffset": 87.23607659729649,
         "targetOffset": [
           0,
           0,
@@ -721,14 +721,28 @@
           "value": "/brains2/target_controls.tau_fl",
           "enabled": true,
           "color": "#4e98e2",
-          "label": "u_tau"
+          "label": "tau_fl"
         },
         {
           "timestampMethod": "headerStamp",
-          "value": "/brains2/current_controls.tau_rl",
+          "value": "/brains2/target_controls.tau_fr",
           "enabled": true,
           "color": "#f5774d",
-          "label": "tau"
+          "label": "tau_fr"
+        },
+        {
+          "timestampMethod": "headerStamp",
+          "value": "/brains2/target_controls.tau_rl",
+          "enabled": true,
+          "color": "#f7df71",
+          "label": "tau_rl"
+        },
+        {
+          "timestampMethod": "headerStamp",
+          "value": "/brains2/target_controls.tau_rr",
+          "enabled": true,
+          "color": "#5cd6a9",
+          "label": "tau_rr"
         }
       ],
       "showXAxisLabels": true,

--- a/src/brains2/CMakeLists.txt
+++ b/src/brains2/CMakeLists.txt
@@ -121,7 +121,7 @@ target_link_libraries(sim_node
 # control
 ####################################################################################################
 
-ament_auto_add_library(brains2_control SHARED src/control/controller.cpp)
+ament_auto_add_library(brains2_control SHARED src/control/high_level_controller.cpp src/control/low_level_controller.cpp)
 target_link_libraries(brains2_control m casadi fatrop)
 
 ament_auto_add_executable(control_node src/control/control_node.cpp)

--- a/src/brains2/include/brains2/control/high_level_controller.hpp
+++ b/src/brains2/include/brains2/control/high_level_controller.hpp
@@ -7,13 +7,12 @@
 #include <Eigen/Dense>
 #include "brains2/common/tracks.hpp"
 #include "brains2/external/expected.hpp"
-#include "brains2/sim/sim.hpp"
 #include "casadi/casadi.hpp"
 
 namespace brains2 {
 namespace control {
 
-class Controller {
+class HighLevelController {
 public:
     struct ModelParams {
         double dt, m, l_R, l_F, C_m0, C_r0, C_r1, C_r2;
@@ -29,16 +28,16 @@ public:
         std::string solver;
     };
 
-    Controller() = delete;
-    Controller(const Controller&) = delete;
-    Controller& operator=(const Controller&) = delete;
-    virtual ~Controller() = default;
+    HighLevelController() = delete;
+    HighLevelController(const HighLevelController&) = delete;
+    HighLevelController& operator=(const HighLevelController&) = delete;
+    virtual ~HighLevelController() = default;
 
-    Controller(size_t Nf,
-               const ModelParams& model_params,
-               const ConstraintsParams& limits,
-               const CostParams& cost_params,
-               const SolverParams& solver_params = {false, "fatrop"});
+    HighLevelController(size_t Nf,
+                        const ModelParams& model_params,
+                        const ConstraintsParams& limits,
+                        const CostParams& cost_params,
+                        const SolverParams& solver_params = {false, "fatrop"});
 
     struct State {
         double s, n, psi, v;
@@ -124,14 +123,9 @@ private:
     casadi::MX x0, kappa_cen, w_cen;
 };
 
-std::string to_string(const Controller::Error& error);
+typedef HighLevelController HLC;
 
-/*
- * @brief Converts the control command internally used by the controller to the format used by the
- *        simulator. Concretely, it splits the global torque command into four torques (one for each
- *        wheel). For the moment it does so by evenly splitting them, without any torque vectoring.
- */
-brains2::sim::Sim::Control to_sim_control(const Controller::Control& control);
+std::string to_string(const HLC::Error& error);
 
 }  // namespace control
 }  // namespace brains2

--- a/src/brains2/include/brains2/control/low_level_controller.hpp
+++ b/src/brains2/include/brains2/control/low_level_controller.hpp
@@ -1,6 +1,7 @@
 #ifndef BRAINS2_CONTROL_LOW_LEVEL_CONTROLLER_HPP
 #define BRAINS2_CONTROL_LOW_LEVEL_CONTROLLER_HPP
 
+#include <tuple>
 #include "brains2/control/high_level_controller.hpp"
 #include "brains2/sim/sim.hpp"
 
@@ -16,11 +17,14 @@ public:
     struct ModelParams {
         double m, l_R, l_F, axle_track, z_CG, C_downforce, torque_max;
     };
+    struct Info {
+        double omega_err, delta_tau;
+    };
 
     LowLevelController() = delete;
     LowLevelController(const double K_tv, const ModelParams& model_params);
 
-    Control compute_control(const State& state, const HLC::Control& control);
+    std::pair<Control, Info> compute_control(const State& state, const HLC::Control& control);
 
 private:
     double K_tv;

--- a/src/brains2/include/brains2/control/low_level_controller.hpp
+++ b/src/brains2/include/brains2/control/low_level_controller.hpp
@@ -1,0 +1,34 @@
+#ifndef BRAINS2_CONTROL_LOW_LEVEL_CONTROLLER_HPP
+#define BRAINS2_CONTROL_LOW_LEVEL_CONTROLLER_HPP
+
+#include "brains2/control/high_level_controller.hpp"
+#include "brains2/sim/sim.hpp"
+
+namespace brains2 {
+namespace control {
+
+class LowLevelController {
+public:
+    struct State {
+        double v_x, v_y, omega, a_x, a_y;
+    };
+    using Control = brains2::sim::Sim::Control;
+    struct ModelParams {
+        double m, l_R, l_F, axle_track, z_CG, C_downforce, torque_max;
+    };
+
+    LowLevelController() = delete;
+    LowLevelController(const double K_tv, const ModelParams& model_params);
+
+    Control compute_control(const State& state, const HLC::Control& control);
+
+private:
+    double K_tv;
+    ModelParams model_params;
+};
+typedef LowLevelController LLC;
+
+}  // namespace control
+}  // namespace brains2
+
+#endif

--- a/src/brains2/src/control/control_node.cpp
+++ b/src/brains2/src/control/control_node.cpp
@@ -214,7 +214,8 @@ private:
     void control_cb() {
         if (!this->pose_msg || !this->vel_msg || !this->accel_msg) {
             RCLCPP_INFO(this->get_logger(),
-                        "Pose or velocity message not received; skipping control computation");
+                        "Pose, velocity or acceleration message not received; skipping control "
+                        "computation");
             return;
         }
         if (!this->track) {

--- a/src/brains2/src/control/low_level_controller.cpp
+++ b/src/brains2/src/control/low_level_controller.cpp
@@ -1,0 +1,52 @@
+#include "brains2/control/low_level_controller.hpp"
+#include "brains2/common/math.hpp"
+
+using namespace brains2::control;
+using namespace brains2::common;
+
+LowLevelController::LowLevelController(const double K_tv, const ModelParams& model_params)
+    : K_tv(K_tv), model_params(model_params) {
+}
+
+LowLevelController::Control LowLevelController::compute_control(const State& state,
+                                                                const HLC::Control& control) {
+    const auto& [m, l_R, l_F, axle_track, z_CG, C_downforce, torque_max] = model_params;
+    const double wheelbase = l_F + l_R;
+
+    // Compute reference torque difference between right and left wheels
+    const auto beta = l_R / wheelbase * control.delta;
+    const auto v = std::hypot(state.v_x, state.v_y);
+    const double omega_kin = v * sin(beta) / l_R;
+    const double delta_tau = K_tv * (omega_kin - state.omega);
+
+    // Compute vertical loads
+    const double F_downforce = 0.5 * C_downforce * state.v_x * state.v_x;
+    const double static_weight = m * 9.81;
+    const double front_weight_distribution = l_F / wheelbase;
+    const double rear_weight_distribution = l_R / wheelbase;
+    const double longitudinal_weight_transfer = m * state.a_x * z_CG / wheelbase;
+    const double lateral_weight_transfer = m * state.a_y * z_CG / axle_track;
+    const double F_z_FL = 0.5 * (front_weight_distribution * (static_weight + F_downforce) -
+                                 longitudinal_weight_transfer - lateral_weight_transfer);
+    const double F_z_FR = 0.5 * (front_weight_distribution * (static_weight + F_downforce) -
+                                 longitudinal_weight_transfer + lateral_weight_transfer);
+    const double F_z_RL = 0.5 * (rear_weight_distribution * (static_weight + F_downforce) +
+                                 longitudinal_weight_transfer - lateral_weight_transfer);
+    const double F_z_RR = 0.5 * (rear_weight_distribution * (static_weight + F_downforce) +
+                                 longitudinal_weight_transfer + lateral_weight_transfer);
+
+    // Adjust the torque of each wheel
+    return {control.delta,
+            clip((control.tau - delta_tau) * F_z_FL / (static_weight + F_downforce),
+                 -torque_max,
+                 torque_max),
+            clip((control.tau + delta_tau) * F_z_FR / (static_weight + F_downforce),
+                 -torque_max,
+                 torque_max),
+            clip((control.tau - delta_tau) * F_z_RL / (static_weight + F_downforce),
+                 -torque_max,
+                 torque_max),
+            clip((control.tau + delta_tau) * F_z_RR / (static_weight + F_downforce),
+                 -torque_max,
+                 torque_max)};
+}

--- a/src/brains2/src/sim/sim_node.cpp
+++ b/src/brains2/src/sim/sim_node.cpp
@@ -417,9 +417,9 @@ public:
             this->create_publisher<Controls>("/brains2/current_controls", 10);
         this->viz_pub =
             this->create_publisher<visualization_msgs::msg::MarkerArray>("/brains2/viz/sim", 10);
-        this->diagnostics_pub =
-            this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/brains2/diagnostics",
-                                                                          10);
+        this->diagnostics_pub = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>(
+            "/brains2/diagnostics/sim",
+            10);
 
         // Create ros subscribers.
         this->target_controls_sub = this->create_subscription<brains2::msg::Controls>(

--- a/src/brains2/tests/control/test_controller.cpp
+++ b/src/brains2/tests/control/test_controller.cpp
@@ -2,7 +2,7 @@
 #include <memory>
 #include <numeric>
 #include "brains2/common/tracks.hpp"
-#include "brains2/control/controller.hpp"
+#include "brains2/control/high_level_controller.hpp"
 #include "brains2/external/icecream.hpp"
 #include "gtest/gtest.h"
 
@@ -33,11 +33,11 @@ static tl::expected<Track, Track::Error> generate_constant_curvature_track(const
 
 class ControllerConstantCurvatureTest : public ::testing::TestWithParam<double> {
 protected:
-    std::unique_ptr<Controller> controller;
+    std::unique_ptr<HighLevelController> controller;
     std::unique_ptr<Track> track;
     void SetUp() override {
-        controller = std::make_unique<Controller>(10,
-                                                  Controller::ModelParams{
+        controller = std::make_unique<HighLevelController>(10,
+                                                  HighLevelController::ModelParams{
                                                       0.05,
                                                       230.0,
                                                       0.7853,
@@ -47,13 +47,13 @@ protected:
                                                       20.0,
                                                       3.0,
                                                   },
-                                                  Controller::ConstraintsParams{
+                                                  HighLevelController::ConstraintsParams{
                                                       10.0,
                                                       0.5,
                                                       100.0,
                                                       1.55,
                                                   },
-                                                  Controller::CostParams{
+                                                  HighLevelController::CostParams{
                                                       3.0,
                                                       1.0,
                                                       1.0,
@@ -76,7 +76,7 @@ protected:
 };
 
 TEST_P(ControllerConstantCurvatureTest, bruh) {
-    auto res = controller->compute_control(Controller::State{0.0, 0.0, 0.0, 0.0}, *track);
+    auto res = controller->compute_control(HighLevelController::State{0.0, 0.0, 0.0, 0.0}, *track);
     ASSERT_TRUE(res.has_value());
     IC(*res, controller->get_x_opt(), controller->get_u_opt());
 }


### PR DESCRIPTION
this PR splits the control module logic into two main classes: `HighLevelController` (`HLC`) and `LowLevelController` (`LLC`). The first one is the MPC controller we implemented before, and the second one implements a simple torque vectoring algorithm.