### PR TITLE
add coordination node and stopping logic

### DIFF
--- a/cleanup_bags.py
+++ b/cleanup_bags.py
@@ -1,0 +1,28 @@
+import shutil
+import os
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--dir", default="bags")
+args = parser.parse_args()
+dir = args.dir
+
+
+# find recursively all the directories that contain an .mcap file
+dirs_to_clean = list(
+    filter(
+        lambda x: set(x[2]) == {"metadata.yaml", f"{x[0].split('/')[-1]}_0.mcap"},
+        os.walk(dir),
+    )
+)
+print(f"Found {len(dirs_to_clean)} directories to clean:")
+print("\n\t - ".join(list(x[0] for x in dirs_to_clean)))
+
+# for each, move the mcap file in the parent directory, removes the _0 from the name, and removes the directory
+for dirpath, _, filenames in dirs_to_clean:
+    basename = dirpath.split("/")[-1]
+    shutil.move(
+        os.path.join(dirpath, f"{basename}_0.mcap"),
+        os.path.join(dirpath, "..", f"{basename}.mcap"),
+    )
+    shutil.rmtree(dirpath)

--- a/foxglove_template.json
+++ b/foxglove_template.json
@@ -250,13 +250,13 @@
     "3D!2u59b2d": {
       "cameraState": {
         "perspective": true,
-        "distance": 10.8072017532524,
-        "phi": 56.04793647469345,
-        "thetaOffset": 87.23607659729649,
+        "distance": 7.547072050704995,
+        "phi": 56.047936474693586,
+        "thetaOffset": 87.23607659729748,
         "targetOffset": [
-          0,
-          0,
-          0
+          -0.06103569712816658,
+          -0.05198458951549887,
+          5.849515594445797e-18
         ],
         "target": [
           0,
@@ -674,46 +674,6 @@
       "followingViewWidth": 10,
       "foxglovePanelTitle": "closed-loop steering (rad)"
     },
-    "Plot!3lwo8o7": {
-      "paths": [
-        {
-          "value": "/brains2/diagnostics.status[:]{hardware_id==\"\"}{name==\"high_level_controller\"}.values[:]{key==\"runtime (ms)\"}.value",
-          "enabled": true,
-          "timestampMethod": "headerStamp",
-          "label": "runtime"
-        }
-      ],
-      "showXAxisLabels": true,
-      "showYAxisLabels": true,
-      "showLegend": true,
-      "legendDisplay": "none",
-      "showPlotValuesInLegend": false,
-      "isSynced": true,
-      "xAxisVal": "timestamp",
-      "sidebarDimension": 240,
-      "foxglovePanelTitle": "runtime (ms)",
-      "followingViewWidth": 10
-    },
-    "Plot!21y01bi": {
-      "paths": [
-        {
-          "timestampMethod": "headerStamp",
-          "value": "/brains2/velocity.v_x",
-          "enabled": true,
-          "color": "#4e98e2"
-        }
-      ],
-      "showXAxisLabels": true,
-      "showYAxisLabels": true,
-      "showLegend": true,
-      "legendDisplay": "none",
-      "showPlotValuesInLegend": false,
-      "isSynced": true,
-      "xAxisVal": "timestamp",
-      "sidebarDimension": 240,
-      "followingViewWidth": 10,
-      "foxglovePanelTitle": "closed-loop velocity (m/s)"
-    },
     "Plot!1zeuiyp": {
       "paths": [
         {
@@ -756,14 +716,71 @@
       "followingViewWidth": 10,
       "foxglovePanelTitle": "closed-loop torque per wheel (Nm)"
     },
+    "Plot!21y01bi": {
+      "paths": [
+        {
+          "timestampMethod": "headerStamp",
+          "value": "/brains2/velocity.v_x",
+          "enabled": true,
+          "color": "#4e98e2"
+        }
+      ],
+      "showXAxisLabels": true,
+      "showYAxisLabels": true,
+      "showLegend": true,
+      "legendDisplay": "none",
+      "showPlotValuesInLegend": false,
+      "isSynced": true,
+      "xAxisVal": "timestamp",
+      "sidebarDimension": 240,
+      "followingViewWidth": 10,
+      "foxglovePanelTitle": "closed-loop velocity (m/s)"
+    },
+    "StateTransitions!u5aaml": {
+      "paths": [
+        {
+          "value": "/brains2/diagnostics.status[:]{hardware_id==\"\"}{name==\"high_level_controller\"}.message",
+          "timestampMethod": "headerStamp",
+          "label": "control status"
+        },
+        {
+          "value": "/brains2/fsm.state",
+          "timestampMethod": "headerStamp",
+          "label": "fsm"
+        }
+      ],
+      "isSynced": true,
+      "xAxisRange": 10,
+      "showPoints": true
+    },
+    "Plot!3lwo8o7": {
+      "paths": [
+        {
+          "value": "/brains2/diagnostics.status[:]{hardware_id==\"\"}{name==\"high_level_controller\"}.values[:]{key==\"runtime (ms)\"}.value",
+          "enabled": true,
+          "timestampMethod": "headerStamp",
+          "label": "runtime"
+        }
+      ],
+      "showXAxisLabels": true,
+      "showYAxisLabels": true,
+      "showLegend": true,
+      "legendDisplay": "none",
+      "showPlotValuesInLegend": false,
+      "isSynced": true,
+      "xAxisVal": "timestamp",
+      "sidebarDimension": 240,
+      "foxglovePanelTitle": "runtime (ms)",
+      "followingViewWidth": 10
+    },
     "DiagnosticStatusPanel!6s2wmp": {
       "topicToRender": "/brains2/diagnostics"
     },
-    "Brains2 Extensions.Call Service Button!2wnmi6j": {
-      "service": "/brains2/reset",
-      "buttonLabel": "reset",
-      "buttonColor": "#ff0087",
-      "foxglovePanelTitle": "Reset simulation"
+    "Brains2 Extensions.Call Service Button!1iqqegp": {
+      "service": "/brains2/start",
+      "buttonLabel": "start",
+      "buttonColor": "#08ca35",
+      "foxglovePanelTitle": "start"
     },
     "Brains2 Extensions.Call Service Button!3tt1tjl": {
       "service": "/brains2/publish_cones_markers",
@@ -835,29 +852,35 @@
               "first": {
                 "first": {
                   "first": "Plot!3ra6qj8",
-                  "second": "Plot!3lwo8o7",
+                  "second": "Plot!1zeuiyp",
                   "direction": "column"
                 },
                 "second": {
                   "first": "Plot!21y01bi",
-                  "second": "Plot!1zeuiyp",
-                  "direction": "column"
+                  "second": {
+                    "first": "StateTransitions!u5aaml",
+                    "second": "Plot!3lwo8o7",
+                    "direction": "column",
+                    "splitPercentage": 60.89743589743589
+                  },
+                  "direction": "column",
+                  "splitPercentage": 34.84390486851125
                 },
                 "direction": "row"
               },
               "second": {
                 "first": {
                   "first": "DiagnosticStatusPanel!6s2wmp",
-                  "second": "Brains2 Extensions.Call Service Button!2wnmi6j",
+                  "second": "Brains2 Extensions.Call Service Button!1iqqegp",
                   "direction": "column",
-                  "splitPercentage": 76.91321465827639
+                  "splitPercentage": 80.24259388850014
                 },
                 "second": "Brains2 Extensions.Call Service Button!3tt1tjl",
                 "direction": "column",
-                "splitPercentage": 83.50214257888584
+                "splitPercentage": 84.20466123280693
               },
               "direction": "row",
-              "splitPercentage": 80.73322932917316
+              "splitPercentage": 80.26796589524969
             },
             "direction": "column",
             "splitPercentage": 64.34474616292798

--- a/launch/v0.yml
+++ b/launch/v0.yml
@@ -49,6 +49,12 @@ launch:
                 value: $(var track_name)
         - node:
             pkg: "brains2"
+            exec: "coordination_node"
+            param:
+              - name: "laps"
+                value: 1
+        - node:
+            pkg: "brains2"
             exec: "fake_track_estimation_node"
             param:
               - name: "track_name"

--- a/launch/v0.yml
+++ b/launch/v0.yml
@@ -36,7 +36,7 @@ launch:
       name: "bag_file"
       default: ""
   - executable:
-      cmd: "ros2 bag record -s mcap -e '(brains2)|(tf)|(parameter_events)|(rosout)' -o $(var bag_file)"
+      cmd: "ros2 bag record --storage mcap --storage-config-file mcap_writer_options.yml --regex '(brains2)|(tf)|(parameter_events)|(rosout)' --output $(var bag_file)"
       if: $(eval "'$(var bag_file)' != ''")
   - timer:
       period: 1.0

--- a/mcap_writer_options.yml
+++ b/mcap_writer_options.yml
@@ -1,0 +1,8 @@
+noChunkCRC: false
+noChunking: false
+noMessageIndex: false
+noSummary: false
+chunkSize: 786432
+compression: "Zstd"
+compressionLevel: "Default"
+forceCompression: false

--- a/src/brains2/CMakeLists.txt
+++ b/src/brains2/CMakeLists.txt
@@ -59,6 +59,7 @@ set(msg_files
   "msg/Acceleration.msg"
   "msg/ControllerDebugInfo.msg"
   "msg/Controls.msg"
+  "msg/FSM.msg"
   "msg/Map.msg"
   "msg/Pose.msg"
   "msg/TrackEstimate.msg"
@@ -162,6 +163,15 @@ ament_auto_add_executable(fake_slam_node src/slam/fake_slam_node.cpp)
 target_link_libraries(fake_slam_node
   "${cpp_typesupport_target}" # for custom message and service types defined in this package
   yaml-cpp::yaml-cpp
+  brains2_common
+)
+
+####################################################################################################
+# coordination
+####################################################################################################
+ament_auto_add_executable(coordination_node src/coordination/coordination_node.cpp)
+target_link_libraries(coordination_node
+  "${cpp_typesupport_target}" # for custom message and service types defined in this package
   brains2_common
 )
 

--- a/src/brains2/include/brains2/control/high_level_controller.hpp
+++ b/src/brains2/include/brains2/control/high_level_controller.hpp
@@ -66,8 +66,8 @@ public:
      * @param track The current track estimate.
      * @return A control command or an error.
      */
-    tl::expected<Control, Error> compute_control(const State& current_state,
-                                                 const brains2::common::Track& track);
+    tl::expected<std::vector<Control>, Error> compute_control(const State& current_state,
+                                                              const brains2::common::Track& track);
 
     /*
      * @brief Get the horizon size.

--- a/src/brains2/msg/FSM.msg
+++ b/src/brains2/msg/FSM.msg
@@ -1,0 +1,8 @@
+# Copyright (c) 2024. Tudor Oancea, Matteo Berthet
+std_msgs/Header header
+uint8 IDLE = 0
+uint8 RACING = 1
+uint8 NOMINAL_STOPPING = 2
+uint8 EMERGENCY_STOPPING = 3
+uint8 STOPPED = 4
+uint8 state

--- a/src/brains2/src/coordination/README.md
+++ b/src/brains2/src/coordination/README.md
@@ -1,0 +1,37 @@
+# Coordination 
+
+The goal of the node is to keep track of the outputs of every other module and create a global FSM summarized in the following diagram:
+```mermaid
+%%{init: {"flowchart": {"htmlLabels": false}} }%%
+flowchart 
+    I["`IDLE`"]
+    R[RACING]
+    E[EMERGENCY_STOPPING]
+    N[NOMINAL_STOPPING]
+    S[STOPPED]
+
+    I -->|"**/brains2/start**
+    manual trigger"| R
+    R -->|"**/brains2/pose**
+    track progress"| N
+    I -->|"**/brains2/diagnostics**
+    error diagnostic"| E
+    R -->|"**/brains2/diagnostics**
+    error diagnostic"| E
+    N -->|"**/brains2/diagnostics**
+    error diagnostic"| E
+    
+    N -->|"**/brains2/velocity** 
+    v≈0"| S
+    E -->|"**/brains2/velocity** 
+    v≈0"| S
+
+```
+The FSM state is published periodically every 10ms and at every state transition to be sure that the system reacts as quickly as possible.
+
+The logic of the transition `RACING -> NOMINAL_STOPPING` is quite simple and leverages a global representation of the track with _a consistent track progress variable $s$_.
+We keep track of the current track progress $s^\mathrm{proj}$ at every new pose message, and increment a lap counter whenever we pass a certain threshold (that should be slightly beyond 6m). 
+To avoid spurious lap count increments because of pose measurement noise (which could in the worst cases "jump rope" with the finish line), we also enforce that 1s occurs between every increment.
+
+Leveraging the track progress instead of the orange cones lets us reuse the same logic in v0 (where we don't have any node to detect these cones) and following versions (where the SLAM node will be responsible of it). 
+It poses a hard constraint on the SLAM concept that needs to be able to support loop closure, and the TE concept that needs to accordingly update the track representation once the loop closure is detected.

--- a/src/brains2/src/coordination/coordination_node.cpp
+++ b/src/brains2/src/coordination/coordination_node.cpp
@@ -35,34 +35,41 @@ public:
         this->declare_parameter("laps", 1);
         this->declare_parameter("s_thresh", 7.0);
 
-        this->fsm_pub = this->create_publisher<FSM>("fsm", 10);
+        // Initialize FSM state
+        this->fsm.state = FSM::IDLE;
+
+        // Create publishers, subscribers, services and timers
+        this->fsm_pub = this->create_publisher<FSM>("/brains2/fsm", 10);
         this->diag_sub = this->create_subscription<DiagnosticArray>(
-            "diagnostics",
+            "/brains2/diagnostics",
             10,
             [this](const DiagnosticArray::ConstSharedPtr msg) { this->diag_cb(msg); });
         this->track_estimate_sub = this->create_subscription<TrackEstimate>(
             "/brains2/track_estimate",
             10,
             [this](const TrackEstimate::ConstSharedPtr msg) { this->track_estimate_cb(msg); });
+        this->vel_sub = this->create_subscription<Velocity>(
+            "/brains2/velocity",
+            10,
+            [this](const Velocity::ConstSharedPtr msg) { this->vel_cb(msg); });
         this->pose_sub = this->create_subscription<Pose>(
             "/brains2/pose",
             10,
             [this](const Pose::ConstSharedPtr msg) { this->pose_cb(msg); });
         this->start_srv = this->create_service<std_srvs::srv::Empty>(
-            "start",
+            "/brains2/start",
             [this](const std_srvs::srv::Empty::Request::SharedPtr req,
                    const std_srvs::srv::Empty::Response::SharedPtr res) { this->start_cb(); });
+        this->timer = this->create_wall_timer(std::chrono::milliseconds(10),
+                                              [this]() { this->periodic_fsm_state_publish(); });
     }
 
 private:
+    // FSM state
     Publisher<FSM>::SharedPtr fsm_pub;
     FSM fsm;
-    void update_fsm(const uint8_t state) {
-        this->fsm.header.stamp = this->now();
-        this->fsm.state = state;
-        this->fsm_pub->publish(this->fsm);
-    }
 
+    // Error diagnostic make the state transition to EMERGENCY_STOPPING
     Subscription<DiagnosticArray>::SharedPtr diag_sub;
     void diag_cb(const DiagnosticArray::ConstSharedPtr msg) {
         for (const auto &status : msg->status) {
@@ -72,12 +79,15 @@ private:
                              status.name.c_str(),
                              status.message.c_str());
                 if (this->fsm.state != FSM::EMERGENCY_STOPPING && this->fsm.state != FSM::STOPPED) {
-                    update_fsm(FSM::EMERGENCY_STOPPING);
+                    this->fsm.header.stamp = this->now();
+                    this->fsm.state = FSM::EMERGENCY_STOPPING;
+                    this->fsm_pub->publish(this->fsm);
                 }
             }
         }
     }
 
+    // Receive track estimate messages
     Subscription<TrackEstimate>::SharedPtr track_estimate_sub;
     unique_ptr<Track> track;
     void track_estimate_cb(const TrackEstimate::ConstSharedPtr msg) {
@@ -92,57 +102,77 @@ private:
                 this->get_logger(),
                 "Could not construct Track object from received message because of error: %s",
                 to_string(track_expected.error()).c_str());
+            // TODO: what do we do when the track estimate is invalid? do we directly go into
+            // EMERGENCY_STOPPING?
+            // If there is a problem with the TE node, it will probably already send an error
+            // diagnostic, so we will either way transition to EMERGENCY_STOPPING.
         } else {
             this->track = std::make_unique<Track>(*track_expected);
         }
     }
 
-    Subscription<Velocity>::SharedPtr vel_pub;
+    // Check for small velocities to know when we stopped
+    Subscription<Velocity>::SharedPtr vel_sub;
     void vel_cb(const Velocity::ConstSharedPtr msg) {
         if ((this->fsm.state == FSM::NOMINAL_STOPPING ||
              this->fsm.state == FSM::EMERGENCY_STOPPING) &&
             std::hypot(msg->v_x, msg->v_y) < 0.01) {
-            update_fsm(FSM::STOPPED);
+            this->fsm.header.stamp = this->now();
+            this->fsm.state = FSM::STOPPED;
+            this->fsm_pub->publish(this->fsm);
         }
     }
 
+    // Check if the pose made enough track progress to count a lap
     Subscription<Pose>::SharedPtr pose_sub;
     double s_proj = 0.0, last_s_proj = 0.0;
     int8_t completed_laps = -1;
     static constexpr uint64_t MIN_STEPS_SINCE_LAST_LAP = 100;
     uint64_t steps_since_last_lap = MIN_STEPS_SINCE_LAST_LAP;
     void pose_cb(const Pose::ConstSharedPtr msg) {
-        if (!this->track) {
-            return;
-        }
-        // Project pose
-        const auto [s, pos] = this->track->project(msg->x, msg->y, s_proj, 10.0);
-        last_s_proj = s_proj;
-        s_proj = s;
-        // Check if we have completed a lap
-        // NOTE: we require a certain number of steps since the last lap to avoid incrementing the
-        // lap counter because of position noise that can make us jumping rope with the finish line.
-        const auto s_thresh = this->get_parameter("s_thresh").as_double();
-        if (steps_since_last_lap >= MIN_STEPS_SINCE_LAST_LAP && last_s_proj < s_thresh &&
-            s_proj >= s_thresh) {
-            completed_laps++;
-            steps_since_last_lap = 0;
-        } else {
-            steps_since_last_lap++;
-        }
+        // If we are in RACING state, check if we have completed the required number of laps
+        if (this->fsm.state == FSM::RACING && this->track) {
+            // Project pose
+            const auto [s, pos] = this->track->project(msg->x, msg->y, s_proj, 10.0);
+            last_s_proj = s_proj;
+            s_proj = s;
+            // Check if we have completed a lap
+            // NOTE: we require a certain number of steps since the last lap to avoid incrementing
+            // the lap counter because of position noise that can make us jumping rope with the
+            // finish line.
+            const auto s_thresh = this->get_parameter("s_thresh").as_double();
+            if (steps_since_last_lap >= MIN_STEPS_SINCE_LAST_LAP && last_s_proj < s_thresh &&
+                s_proj >= s_thresh) {
+                completed_laps++;
+                steps_since_last_lap = 0;
+            } else {
+                steps_since_last_lap++;
+            }
 
-        // Stop after a certain number of laps
-        if (completed_laps >= this->get_parameter("laps").as_int()) {
-            update_fsm(FSM::NOMINAL_STOPPING);
+            // Stop after a certain number of laps
+            if (completed_laps >= this->get_parameter("laps").as_int()) {
+                this->fsm.header.stamp = this->now();
+                this->fsm.state = FSM::NOMINAL_STOPPING;
+                this->fsm_pub->publish(this->fsm);
+            }
         }
     }
 
+    // Start the system on manual trigger
     Service<std_srvs::srv::Empty>::SharedPtr start_srv;
     void start_cb() {
-        if (this->fsm.state != FSM::IDLE) {
-            return;
+        if (this->fsm.state == FSM::IDLE) {
+            this->fsm.header.stamp = this->now();
+            this->fsm.state = FSM::RACING;
+            this->fsm_pub->publish(this->fsm);
         }
-        this->update_fsm(FSM::RACING);
+    }
+
+    // Publish the FSM state periodically
+    rclcpp::TimerBase::SharedPtr timer;
+    void periodic_fsm_state_publish() {
+        this->fsm.header.stamp = this->now();
+        this->fsm_pub->publish(this->fsm);
     }
 };
 

--- a/src/brains2/src/coordination/coordination_node.cpp
+++ b/src/brains2/src/coordination/coordination_node.cpp
@@ -1,0 +1,159 @@
+#include <algorithm>
+#include <cmath>
+#include <Eigen/Dense>
+#include <memory>
+#include <numeric>
+#include "brains2/common/marker_color.hpp"
+#include "brains2/common/math.hpp"
+#include "brains2/common/tracks.hpp"
+#include "brains2/external/icecream.hpp"
+#include "brains2/msg/fsm.hpp"
+#include "brains2/msg/pose.hpp"
+#include "brains2/msg/track_estimate.hpp"
+#include "brains2/msg/velocity.hpp"
+#include "diagnostic_msgs/msg/diagnostic_array.hpp"
+#include "diagnostic_msgs/msg/diagnostic_status.hpp"
+#include "rclcpp/logging.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/publisher.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/subscription.hpp"
+#include "std_srvs/srv/empty.hpp"
+
+using namespace std;
+using namespace brains2::msg;
+using namespace brains2::common;
+using diagnostic_msgs::msg::DiagnosticArray;
+using diagnostic_msgs::msg::DiagnosticStatus;
+using rclcpp::Publisher;
+using rclcpp::Service;
+using rclcpp::Subscription;
+
+class CoordinationNode : public rclcpp::Node {
+public:
+    CoordinationNode() : Node("coordination_node") {
+        this->declare_parameter("laps", 1);
+        this->declare_parameter("s_thresh", 7.0);
+
+        this->fsm_pub = this->create_publisher<FSM>("fsm", 10);
+        this->diag_sub = this->create_subscription<DiagnosticArray>(
+            "diagnostics",
+            10,
+            [this](const DiagnosticArray::ConstSharedPtr msg) { this->diag_cb(msg); });
+        this->track_estimate_sub = this->create_subscription<TrackEstimate>(
+            "/brains2/track_estimate",
+            10,
+            [this](const TrackEstimate::ConstSharedPtr msg) { this->track_estimate_cb(msg); });
+        this->pose_sub = this->create_subscription<Pose>(
+            "/brains2/pose",
+            10,
+            [this](const Pose::ConstSharedPtr msg) { this->pose_cb(msg); });
+        this->start_srv = this->create_service<std_srvs::srv::Empty>(
+            "start",
+            [this](const std_srvs::srv::Empty::Request::SharedPtr req,
+                   const std_srvs::srv::Empty::Response::SharedPtr res) { this->start_cb(); });
+    }
+
+private:
+    Publisher<FSM>::SharedPtr fsm_pub;
+    FSM fsm;
+    void update_fsm(const uint8_t state) {
+        this->fsm.header.stamp = this->now();
+        this->fsm.state = state;
+        this->fsm_pub->publish(this->fsm);
+    }
+
+    Subscription<DiagnosticArray>::SharedPtr diag_sub;
+    void diag_cb(const DiagnosticArray::ConstSharedPtr msg) {
+        for (const auto &status : msg->status) {
+            if (status.level == DiagnosticStatus::ERROR) {
+                RCLCPP_ERROR(this->get_logger(),
+                             "Diagnostic from %s has error \"%s\"",
+                             status.name.c_str(),
+                             status.message.c_str());
+                if (this->fsm.state != FSM::EMERGENCY_STOPPING && this->fsm.state != FSM::STOPPED) {
+                    update_fsm(FSM::EMERGENCY_STOPPING);
+                }
+            }
+        }
+    }
+
+    Subscription<TrackEstimate>::SharedPtr track_estimate_sub;
+    unique_ptr<Track> track;
+    void track_estimate_cb(const TrackEstimate::ConstSharedPtr msg) {
+        const auto track_expected = Track::from_values(msg->s_cen,
+                                                       msg->x_cen,
+                                                       msg->y_cen,
+                                                       msg->phi_cen,
+                                                       msg->kappa_cen,
+                                                       msg->w_cen);
+        if (!track_expected) {
+            RCLCPP_ERROR(
+                this->get_logger(),
+                "Could not construct Track object from received message because of error: %s",
+                to_string(track_expected.error()).c_str());
+        } else {
+            this->track = std::make_unique<Track>(*track_expected);
+        }
+    }
+
+    Subscription<Velocity>::SharedPtr vel_pub;
+    void vel_cb(const Velocity::ConstSharedPtr msg) {
+        if ((this->fsm.state == FSM::NOMINAL_STOPPING ||
+             this->fsm.state == FSM::EMERGENCY_STOPPING) &&
+            std::hypot(msg->v_x, msg->v_y) < 0.01) {
+            update_fsm(FSM::STOPPED);
+        }
+    }
+
+    Subscription<Pose>::SharedPtr pose_sub;
+    double s_proj = 0.0, last_s_proj = 0.0;
+    int8_t completed_laps = -1;
+    static constexpr uint64_t MIN_STEPS_SINCE_LAST_LAP = 100;
+    uint64_t steps_since_last_lap = MIN_STEPS_SINCE_LAST_LAP;
+    void pose_cb(const Pose::ConstSharedPtr msg) {
+        if (!this->track) {
+            return;
+        }
+        // Project pose
+        const auto [s, pos] = this->track->project(msg->x, msg->y, s_proj, 10.0);
+        last_s_proj = s_proj;
+        s_proj = s;
+        // Check if we have completed a lap
+        // NOTE: we require a certain number of steps since the last lap to avoid incrementing the
+        // lap counter because of position noise that can make us jumping rope with the finish line.
+        const auto s_thresh = this->get_parameter("s_thresh").as_double();
+        if (steps_since_last_lap >= MIN_STEPS_SINCE_LAST_LAP && last_s_proj < s_thresh &&
+            s_proj >= s_thresh) {
+            completed_laps++;
+            steps_since_last_lap = 0;
+        } else {
+            steps_since_last_lap++;
+        }
+
+        // Stop after a certain number of laps
+        if (completed_laps >= this->get_parameter("laps").as_int()) {
+            update_fsm(FSM::NOMINAL_STOPPING);
+        }
+    }
+
+    Service<std_srvs::srv::Empty>::SharedPtr start_srv;
+    void start_cb() {
+        if (this->fsm.state != FSM::IDLE) {
+            return;
+        }
+        this->update_fsm(FSM::RACING);
+    }
+};
+
+int main(int argc, char **argv) {
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<CoordinationNode>();
+    try {
+        rclcpp::spin(node);
+    } catch (std::exception &e) {
+        RCLCPP_FATAL(node->get_logger(), "Caught exception: %s", e.what());
+    }
+    rclcpp::shutdown();
+    return 0;
+}

--- a/src/brains2/tests/control/test_controller.cpp
+++ b/src/brains2/tests/control/test_controller.cpp
@@ -37,35 +37,35 @@ protected:
     std::unique_ptr<Track> track;
     void SetUp() override {
         controller = std::make_unique<HighLevelController>(10,
-                                                  HighLevelController::ModelParams{
-                                                      0.05,
-                                                      230.0,
-                                                      0.7853,
-                                                      0.7853,
-                                                      4.950,
-                                                      350.0,
-                                                      20.0,
-                                                      3.0,
-                                                  },
-                                                  HighLevelController::ConstraintsParams{
-                                                      10.0,
-                                                      0.5,
-                                                      100.0,
-                                                      1.55,
-                                                  },
-                                                  HighLevelController::CostParams{
-                                                      3.0,
-                                                      1.0,
-                                                      1.0,
-                                                      1.0,
-                                                      1.0,
-                                                      1.0,
-                                                      1.0,
-                                                      1.0,
-                                                      1.0,
-                                                      1.0,
-                                                      1.0,
-                                                  });
+                                                           HighLevelController::ModelParams{
+                                                               0.05,
+                                                               230.0,
+                                                               0.7853,
+                                                               0.7853,
+                                                               4.950,
+                                                               350.0,
+                                                               20.0,
+                                                               3.0,
+                                                           },
+                                                           HighLevelController::ConstraintsParams{
+                                                               10.0,
+                                                               0.5,
+                                                               100.0,
+                                                               1.55,
+                                                           },
+                                                           HighLevelController::CostParams{
+                                                               3.0,
+                                                               1.0,
+                                                               1.0,
+                                                               1.0,
+                                                               1.0,
+                                                               1.0,
+                                                               1.0,
+                                                               1.0,
+                                                               1.0,
+                                                               1.0,
+                                                               1.0,
+                                                           });
         auto curvature = GetParam();
         const auto track_expected = generate_constant_curvature_track(curvature, 4.0, 5);
         if (!track_expected) {
@@ -78,7 +78,7 @@ protected:
 TEST_P(ControllerConstantCurvatureTest, bruh) {
     auto res = controller->compute_control(HighLevelController::State{0.0, 0.0, 0.0, 0.0}, *track);
     ASSERT_TRUE(res.has_value());
-    IC(*res, controller->get_x_opt(), controller->get_u_opt());
+    // IC(*res, controller->get_x_opt(), controller->get_u_opt());
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
fixes #77 

This PR adds a new important node, the `coordination_node`, which is in charge to coordinate all the other components of the system. It acts as a global FSM that knows when to start the car, when to stop it, when to trigger an emergency, and how to inform the nodes accordingly.