### PR TITLE
Add 1OS steering model in HLC

### DIFF
--- a/car_constants.yaml
+++ b/car_constants.yaml
@@ -61,6 +61,6 @@ wheels:
 actuators:
   torque_max: 276.75
   steering_max: 0.5
-  steering_rate_max: 1.0
+  steering_rate_max: 10.0
   motor_time_constant: 1e-3
   steering_time_constant: 0.02

--- a/car_constants.yaml
+++ b/car_constants.yaml
@@ -61,6 +61,6 @@ wheels:
 actuators:
   torque_max: 276.75
   steering_max: 0.5
-  steering_rate_max: 10.0
+  steering_rate_max: 1.0
   motor_time_constant: 1e-3
   steering_time_constant: 0.02

--- a/cleanup_bags.py
+++ b/cleanup_bags.py
@@ -15,8 +15,10 @@ dirs_to_clean = list(
         os.walk(dir),
     )
 )
-print(f"Found {len(dirs_to_clean)} directories to clean:")
-print("\n\t - ".join(list(x[0] for x in dirs_to_clean)))
+print(
+    f"Found {len(dirs_to_clean)} directories to clean:",
+    "".join(list("\n\t - " + x[0] for x in dirs_to_clean)),
+)
 
 # for each, move the mcap file in the parent directory, removes the _0 from the name, and removes the directory
 for dirpath, _, filenames in dirs_to_clean:

--- a/cleanup_bags.py
+++ b/cleanup_bags.py
@@ -17,7 +17,7 @@ dirs_to_clean = list(
 )
 print(
     f"Found {len(dirs_to_clean)} directories to clean:",
-    "".join(list("\n\t - " + x[0] for x in dirs_to_clean)),
+    "".join(list("\n  - " + x[0] for x in dirs_to_clean)),
 )
 
 # for each, move the mcap file in the parent directory, removes the _0 from the name, and removes the directory

--- a/launch/v0.yml
+++ b/launch/v0.yml
@@ -27,14 +27,14 @@ launch:
       name: "r_delta"
       default: "2.0"
   - arg:
-      name: "r_delta_dot"
-      default: "1.0"
-  - arg:
       name: "r_tau"
       default: "0.001"
   - arg:
       name: "final_mul"
       default: "1000.0"
+  - arg:
+      name: "K_tv"
+      default: "300.0"
   - arg:
       name: "bag_file"
       default: ""
@@ -78,8 +78,6 @@ launch:
                 value: $(var Nf)
               - name: "v_ref"
                 value: $(var v_ref)
-              - name: "tau_max"
-                value: 200.0
               - name: "q_s"
                 value: $(var q_s)
               - name: "q_n"
@@ -100,3 +98,5 @@ launch:
                 value: $(eval "$(var final_mul) * $(var q_psi)")
               - name: "q_v_f"
                 value: $(eval "$(var final_mul) * $(var q_v)")
+              - name: "K_tv"
+                value: $(var K_tv)

--- a/launch/v0.yml
+++ b/launch/v0.yml
@@ -27,6 +27,9 @@ launch:
       name: "r_delta"
       default: "2.0"
   - arg:
+      name: "r_delta_dot"
+      default: "1.0"
+  - arg:
       name: "r_tau"
       default: "0.001"
   - arg:

--- a/src/brains2/include/brains2/control/high_level_controller.hpp
+++ b/src/brains2/include/brains2/control/high_level_controller.hpp
@@ -15,13 +15,14 @@ namespace control {
 class HighLevelController {
 public:
     struct ModelParams {
-        double dt, m, l_R, l_F, C_m0, C_r0, C_r1, C_r2;
+        double dt, m, l_R, l_F, C_m0, C_r0, C_r1, C_r2, t_delta;
     };
     struct CostParams {
-        double v_ref, q_s, q_n, q_psi, q_v, r_delta, r_tau, q_s_f, q_n_f, q_psi_f, q_v_f;
+        double v_ref, q_s, q_n, q_psi, q_v, r_delta, r_delta_dot, r_tau, q_s_f, q_n_f, q_psi_f,
+            q_v_f;
     };
     struct ConstraintsParams {
-        double v_x_max, delta_max, tau_max, car_width;
+        double v_max, delta_max, delta_dot_max, tau_max, car_width;
     };
     struct SolverParams {
         bool jit;
@@ -40,10 +41,10 @@ public:
                         const SolverParams& solver_params = {false, "fatrop"});
 
     struct State {
-        double s, n, psi, v;
+        double s, n, psi, v, delta;
     };
     struct Control {
-        double delta, tau;
+        double u_delta, tau;
     };
     static constexpr uint8_t nx = sizeof(State) / sizeof(double);
     static constexpr uint8_t nu = sizeof(Control) / sizeof(double);

--- a/src/brains2/include/brains2/control/low_level_controller.hpp
+++ b/src/brains2/include/brains2/control/low_level_controller.hpp
@@ -11,7 +11,7 @@ namespace control {
 class LowLevelController {
 public:
     struct State {
-        double v_x, v_y, omega, a_x, a_y;
+        double v_x, v_y, omega, a_x, a_y, delta;
     };
     using Control = brains2::sim::Sim::Control;
     struct ModelParams {

--- a/src/brains2/msg/ControllerDebugInfo.msg
+++ b/src/brains2/msg/ControllerDebugInfo.msg
@@ -11,4 +11,6 @@ float64[] n_pred
 float64[] psi_pred
 float64[] v_pred
 float64[] delta_pred
+float64[] u_delta_pred
 float64[] tau_pred
+float64[] delta_dot_pred

--- a/src/brains2/src/control/high_level_controller.cpp
+++ b/src/brains2/src/control/high_level_controller.cpp
@@ -154,9 +154,11 @@ HighLevelController::HighLevelController(
                 opti.bounded(-constraints_params.delta_max, u[i](0), constraints_params.delta_max));
             opti.subject_to(
                 opti.bounded(-constraints_params.tau_max, u[i](1), constraints_params.tau_max));
-            opti.subject_to(opti.bounded(-constraints_params.delta_dot_max * model_params.t_delta,
-                                         u[i](0) - x[i](4),
-                                         constraints_params.delta_dot_max * model_params.t_delta));
+            // opti.subject_to(opti.bounded(-constraints_params.delta_dot_max *
+            // model_params.t_delta,
+            //                              u[i](0) - x[i](4),
+            //                              constraints_params.delta_dot_max *
+            //                              model_params.t_delta));
         }
         // State constraints
         if (i > 0) {

--- a/src/brains2/src/control/low_level_controller.cpp
+++ b/src/brains2/src/control/low_level_controller.cpp
@@ -14,7 +14,7 @@ LowLevelController::compute_control(const State& state, const HLC::Control& cont
     const double wheelbase = l_F + l_R;
 
     // Compute reference torque difference between right and left wheels
-    const auto beta = l_R / wheelbase * control.delta;
+    const auto beta = l_R / wheelbase * state.delta;
     const auto v = std::hypot(state.v_x, state.v_y);
     const double omega_kin = v * sin(beta) / l_R;
     const double delta_tau = K_tv * (omega_kin - state.omega);
@@ -37,7 +37,7 @@ LowLevelController::compute_control(const State& state, const HLC::Control& cont
 
     // Adjust the torque of each wheel
     return std::make_pair(
-        Control{control.delta,
+        Control{control.u_delta,
                 clip((control.tau - delta_tau) * F_z_FL / (static_weight + F_downforce),
                      -torque_max,
                      torque_max),


### PR DESCRIPTION
this PR modifies the HLC formulation to include the same 1st Order System (1OS) model that is used in the simulator. This gives the controller a better idea of the delay induced by the steering actuator. 
The corresponding target and actual steering values, as well as the steering rate have also be added to the `ControllerDebugInfo` messages.

We have also implemented - but commented out - steering rate constraints and costs. During our experiments, we have observed that adding the constraints with the current $\dot{\delta}_\rm{max}=1 \rm{rad/s}$ makes the car leave the track even in very simple turns (e.g. 1st or 2nd turns on track `gamma`).
Without these constraints and costs, we observe _predicted_ steering rate values of up to $35\rm{rad/s}$, but they are never actually reached. 
It seems like the controller benefits from "being optimistic", which might be due to its tuning.

In light of these findings, we will close #84 for now, and investigate in future issues the open-loop/closed-loop discrepancies and the necessity for steering rate constraints.